### PR TITLE
GH-27 Changed generic type names

### DIFF
--- a/multification-core/src/com/eternalcode/multification/Multification.java
+++ b/multification-core/src/com/eternalcode/multification/Multification.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.CheckReturnValue;
 import org.jetbrains.annotations.NotNull;
 
 @SuppressWarnings("UnstableApiUsage")
-public abstract class Multification<Viewer, Translation> {
+public abstract class Multification<VIEWER, TRANSLATION> {
 
     public static final PlatformBroadcaster DEFAULT_BROADCASTER = PlatformBroadcaster.withPlainSerializer();
     public static final AsyncExecutor DEFAULT_EXECUTOR = runnable -> runnable.run();
@@ -25,7 +25,7 @@ public abstract class Multification<Viewer, Translation> {
     public static final LocaleProvider<?> LOCALE_PROVIDER = v -> Locale.ROOT;
 
     @CheckReturnValue
-    public NoticeBroadcast<Viewer, Translation, ?> create() {
+    public NoticeBroadcast<VIEWER, TRANSLATION, ?> create() {
         return new NoticeBroadcastImpl<>(
             this.asyncExecutor(),
             this.translationProvider(),
@@ -38,13 +38,13 @@ public abstract class Multification<Viewer, Translation> {
     }
 
     @NotNull
-    protected abstract ViewerProvider<Viewer> viewerProvider();
+    protected abstract ViewerProvider<VIEWER> viewerProvider();
 
     @NotNull
-    protected abstract TranslationProvider<Translation> translationProvider();
+    protected abstract TranslationProvider<TRANSLATION> translationProvider();
 
     @NotNull
-    protected abstract AudienceConverter<Viewer> audienceConverter();
+    protected abstract AudienceConverter<VIEWER> audienceConverter();
 
     @NotNull
     protected PlatformBroadcaster platformBroadcaster() {
@@ -53,8 +53,8 @@ public abstract class Multification<Viewer, Translation> {
 
     @SuppressWarnings("unchecked")
     @NotNull
-    protected Replacer<Viewer> globalReplacer() {
-        return (Replacer<Viewer>) DEFAULT_REPLACER;
+    protected Replacer<VIEWER> globalReplacer() {
+        return (Replacer<VIEWER>) DEFAULT_REPLACER;
     }
 
     @NotNull
@@ -64,11 +64,11 @@ public abstract class Multification<Viewer, Translation> {
 
     @SuppressWarnings("unchecked")
     @NotNull
-    protected LocaleProvider<Viewer> localeProvider() {
-        return (LocaleProvider<Viewer>) LOCALE_PROVIDER;
+    protected LocaleProvider<VIEWER> localeProvider() {
+        return (LocaleProvider<VIEWER>) LOCALE_PROVIDER;
     }
 
-    public void player(UUID player, NoticeProvider<Translation> extractor, Formatter... formatters) {
+    public void player(UUID player, NoticeProvider<TRANSLATION> extractor, Formatter... formatters) {
         this.create()
             .player(player)
             .notice(extractor)
@@ -76,7 +76,7 @@ public abstract class Multification<Viewer, Translation> {
             .send();
     }
 
-    public void players(Iterable<UUID> players, NoticeProvider<Translation> extractor, Formatter... formatters) {
+    public void players(Iterable<UUID> players, NoticeProvider<TRANSLATION> extractor, Formatter... formatters) {
         this.create()
             .players(players)
             .notice(extractor)
@@ -84,7 +84,7 @@ public abstract class Multification<Viewer, Translation> {
             .send();
     }
 
-    public void viewer(Viewer viewer, NoticeProvider<Translation> extractor, Formatter... formatters) {
+    public void viewer(VIEWER viewer, NoticeProvider<TRANSLATION> extractor, Formatter... formatters) {
         this.create()
             .viewer(viewer)
             .notice(extractor)
@@ -93,7 +93,7 @@ public abstract class Multification<Viewer, Translation> {
     }
 
 
-    public void console(NoticeProvider<Translation> extractor, Formatter... formatters) {
+    public void console(NoticeProvider<TRANSLATION> extractor, Formatter... formatters) {
         this.create()
             .console()
             .notice(extractor)
@@ -101,7 +101,7 @@ public abstract class Multification<Viewer, Translation> {
             .send();
     }
 
-    public void all(NoticeProvider<Translation> extractor, Formatter... formatters) {
+    public void all(NoticeProvider<TRANSLATION> extractor, Formatter... formatters) {
         this.create()
             .all()
             .notice(extractor)

--- a/multification-core/src/com/eternalcode/multification/adventure/AudienceConverter.java
+++ b/multification-core/src/com/eternalcode/multification/adventure/AudienceConverter.java
@@ -2,8 +2,8 @@ package com.eternalcode.multification.adventure;
 
 import net.kyori.adventure.audience.Audience;
 
-public interface AudienceConverter<Viewer> {
+public interface AudienceConverter<VIEWER> {
 
-    Audience convert(Viewer viewer);
+    Audience convert(VIEWER viewer);
 
 }

--- a/multification-core/src/com/eternalcode/multification/locate/LocaleProvider.java
+++ b/multification-core/src/com/eternalcode/multification/locate/LocaleProvider.java
@@ -4,9 +4,9 @@ import java.util.Locale;
 import org.jetbrains.annotations.NotNull;
 
 @FunctionalInterface
-public interface LocaleProvider<Viewer> {
+public interface LocaleProvider<VIEWER> {
 
     @NotNull
-    Locale provide(Viewer viewer);
+    Locale provide(VIEWER viewer);
 
 }

--- a/multification-core/src/com/eternalcode/multification/notice/LanguageViewersIndex.java
+++ b/multification-core/src/com/eternalcode/multification/notice/LanguageViewersIndex.java
@@ -9,11 +9,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-class LanguageViewersIndex<Viewer> {
+class LanguageViewersIndex<VIEWER> {
 
-    private final Map<Locale, Set<Viewer>> viewersByLanguage;
+    private final Map<Locale, Set<VIEWER>> viewersByLanguage;
 
-    private LanguageViewersIndex(Map<Locale, Set<Viewer>> viewersByLanguage) {
+    private LanguageViewersIndex(Map<Locale, Set<VIEWER>> viewersByLanguage) {
         this.viewersByLanguage = viewersByLanguage;
     }
 
@@ -21,14 +21,14 @@ class LanguageViewersIndex<Viewer> {
         return this.viewersByLanguage.keySet();
     }
 
-    Set<Viewer> getViewers(Locale language) {
+    Set<VIEWER> getViewers(Locale language) {
         return this.viewersByLanguage.get(language);
     }
 
-    static <Viewer> LanguageViewersIndex<Viewer> of(LocaleProvider<Viewer> localeProvider, Collection<Viewer> viewers) {
-        Map<Locale, Set<Viewer>> viewersByLanguage = new HashMap<>();
+    static <V> LanguageViewersIndex<V> of(LocaleProvider<V> localeProvider, Collection<V> viewers) {
+        Map<Locale, Set<V>> viewersByLanguage = new HashMap<>();
 
-        for (Viewer viewer : viewers) {
+        for (V viewer : viewers) {
             viewersByLanguage
                 .computeIfAbsent(localeProvider.provide(viewer), key -> new HashSet<>())
                 .add(viewer);

--- a/multification-core/src/com/eternalcode/multification/notice/NoticeBroadcast.java
+++ b/multification-core/src/com/eternalcode/multification/notice/NoticeBroadcast.java
@@ -13,7 +13,7 @@ import java.util.function.Supplier;
 import org.jetbrains.annotations.CheckReturnValue;
 
 @SuppressWarnings("UnstableApiUsage")
-public interface NoticeBroadcast<Viewer, Translation, B extends NoticeBroadcast<Viewer, Translation, B>> {
+public interface NoticeBroadcast<VIEWER, TRANSLATION, B extends NoticeBroadcast<VIEWER, TRANSLATION, B>> {
 
     @CheckReturnValue
     B player(UUID player);
@@ -22,7 +22,7 @@ public interface NoticeBroadcast<Viewer, Translation, B extends NoticeBroadcast<
     B players(Iterable<UUID> players);
 
     @CheckReturnValue
-    B viewer(Viewer viewer);
+    B viewer(VIEWER viewer);
 
     @CheckReturnValue
     B console();
@@ -37,7 +37,7 @@ public interface NoticeBroadcast<Viewer, Translation, B extends NoticeBroadcast<
     B notice(Notice notification);
 
     @CheckReturnValue
-    B notice(NoticeProvider<Translation> extractor);
+    B notice(NoticeProvider<TRANSLATION> extractor);
 
     @CheckReturnValue
     B notice(NoticeType type, String... text);
@@ -46,16 +46,16 @@ public interface NoticeBroadcast<Viewer, Translation, B extends NoticeBroadcast<
     B notice(NoticeType type, Collection<String> text);
 
     @CheckReturnValue
-    B notice(NoticeType type, TextMessageProvider<Translation> extractor);
+    B notice(NoticeType type, TextMessageProvider<TRANSLATION> extractor);
 
     @CheckReturnValue
-    B noticeChat(TextMessageProvider<Translation> extractor);
+    B noticeChat(TextMessageProvider<TRANSLATION> extractor);
 
     @CheckReturnValue
-    B noticeChat(Function<Translation, List<String>> function);
+    B noticeChat(Function<TRANSLATION, List<String>> function);
 
     @CheckReturnValue
-    B noticeOptional(OptionalNoticeProvider<Translation> extractor);
+    B noticeOptional(OptionalNoticeProvider<TRANSLATION> extractor);
 
     @CheckReturnValue
     B placeholder(String from, String to);
@@ -67,7 +67,7 @@ public interface NoticeBroadcast<Viewer, Translation, B extends NoticeBroadcast<
     B placeholder(String from, Supplier<String> to);
 
     @CheckReturnValue
-    B placeholder(String from, TextMessageProvider<Translation> extractor);
+    B placeholder(String from, TextMessageProvider<TRANSLATION> extractor);
 
     @CheckReturnValue
     B formatter(Formatter... formatters);

--- a/multification-core/src/com/eternalcode/multification/shared/Replacer.java
+++ b/multification-core/src/com/eternalcode/multification/shared/Replacer.java
@@ -1,8 +1,8 @@
 package com.eternalcode.multification.shared;
 
 @FunctionalInterface
-public interface Replacer<Viewer> {
+public interface Replacer<VIEWER> {
 
-    String apply(Viewer viewer, String text);
+    String apply(VIEWER viewer, String text);
 
 }

--- a/multification-core/src/com/eternalcode/multification/translation/TranslationProvider.java
+++ b/multification-core/src/com/eternalcode/multification/translation/TranslationProvider.java
@@ -4,9 +4,9 @@ import java.util.Locale;
 import org.jetbrains.annotations.NotNull;
 
 @FunctionalInterface
-public interface TranslationProvider<Translation> {
+public interface TranslationProvider<TRANSLATION> {
 
     @NotNull
-    Translation provide(Locale locale);
+    TRANSLATION provide(Locale locale);
 
 }

--- a/multification-core/src/com/eternalcode/multification/viewer/ViewerProvider.java
+++ b/multification-core/src/com/eternalcode/multification/viewer/ViewerProvider.java
@@ -3,14 +3,14 @@ package com.eternalcode.multification.viewer;
 import java.util.Collection;
 import java.util.UUID;
 
-public interface ViewerProvider<Viewer> {
+public interface ViewerProvider<VIEWER> {
 
-    Viewer console();
+    VIEWER console();
 
-    Viewer player(UUID uuid);
+    VIEWER player(UUID uuid);
 
-    Collection<Viewer> onlinePlayers();
+    Collection<VIEWER> onlinePlayers();
 
-    Collection<Viewer> all();
+    Collection<VIEWER> all();
 
 }


### PR DESCRIPTION
Generic names might be confusing if we name them like classes especially when looking into EternalCore code or other parent project's code. So i suggest to simply use CAPS LOCK :)