### PR TITLE
Fix build for Adventure 5 and bump dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -21,7 +21,7 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Make gradlew executable
         run: chmod +x gradlew

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,11 +1,11 @@
 object Versions {
 
     const val ADVENTURE_PLATFORM_BUKKIT = "4.4.1"
-    const val ADVENTURE_API = "5.0.1"
+    const val ADVENTURE_API = "5.1.1"
     const val CDN = "1.14.9"
 
     const val MOCKITO_CORE = "5.23.0"
-    const val JUNIT_JUPITER = "6.0.3"
+    const val JUNIT_JUPITER = "6.1.0"
     const val ASSERTJ_CORE = "3.27.7"
     const val AWAITILITY = "4.3.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/multification-core/test/com/eternalcode/multification/AudienceMock.java
+++ b/multification-core/test/com/eternalcode/multification/AudienceMock.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.audience.MessageType;
-import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,7 +22,7 @@ class AudienceMock implements Audience {
     }
 
     @Override
-    public void sendMessage(final @NotNull Identity source, final @NotNull Component message, final @NotNull MessageType type) {
+    public void sendMessage(final @NotNull Component message) {
         MESSAGES.computeIfAbsent(uuid, key -> new ArrayList<>()).add(ComponentUtil.componentToText(message));
     }
 


### PR DESCRIPTION
## What

Fixes the broken `./gradlew build` and applies the pending Renovate dependency bumps.

## Why the build was broken

The Adventure 5 upgrade removed `Audience#sendMessage(Identity, Component, MessageType)`, but `AudienceMock` (in `multification-core` tests) still `@Override`-d that now-nonexistent signature and imported the deleted `MessageType`/`Identity` types. This failed `:multification-core:compileTestJava`.

The mock now overrides the surviving `sendMessage(Component)` overload — which is exactly what production calls in `ChatResolver` — so it still captures messages correctly.

## Dependency bumps (from open PRs)

| Dependency | From → To | Renovate PR |
|---|---|---|
| Adventure API | 5.0.1 → 5.1.1 | #137 |
| JUnit | 6.0.3 → 6.1.0 | #138 |
| Gradle wrapper | 9.5.0 → 9.6.0 | #140 |
| actions/checkout | v6 → v7 | #139 |
| gradle/actions/setup-gradle | v5 → v6 | #132 |

### Deliberately left out
- **`paper-api` v26 (#135)** — major-version jump that likely needs code/target changes; out of scope for a green-build fix.
- **README docs (#141)** — not a dependency change.

## Verification

`./gradlew clean build` is **BUILD SUCCESSFUL** on Gradle 9.6.0 — all modules compile and `multification-core` tests run.

> Note: `./gradlew build --rerun-tasks` shows inconsistent inter-module compile races (a pre-existing quirk of the custom `src/` source-set layout under parallel execution), unrelated to these changes. The canonical `build`/`clean build` commands pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)